### PR TITLE
Fix default for text circuit drawer

### DIFF
--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -369,7 +369,7 @@ def _text_circuit_drawer(
     idle_wires=True,
     with_layout=True,
     fold=None,
-    initial_state=True,
+    initial_state=False,
     cregbundle=None,
     encoding=None,
     wire_order=None,
@@ -395,7 +395,7 @@ def _text_circuit_drawer(
             `shutil.get_terminal_size()`. If you don't want pagination
             at all, set `fold=-1`.
         initial_state (bool): Optional. Adds |0> in the beginning of the line.
-            Default: `False`.
+            Default: ``False``.
         cregbundle (bool): Optional. If set True, bundle classical registers.
             Default: ``True``.
         encoding (str): Optional. Sets the encoding preference of the output.

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -709,7 +709,7 @@ class TextDrawing:
         plotbarriers=True,
         line_length=None,
         vertical_compression="high",
-        initial_state=True,
+        initial_state=False,
         cregbundle=None,
         encoding=None,
         with_layout=False,


### PR DESCRIPTION
## Summary
- ensure `_text_circuit_drawer` and `TextDrawing` default to not show
  the initial state

## Testing
- `pytest -k test_circuit_text_drawer.py` *(fails: ModuleNotFoundError: No module named 'ddt')*

------
https://chatgpt.com/codex/tasks/task_e_684333124674832fb4c2139eaafaefac