### PR TITLE
Fix docstring typo in BackendEstimatorV2

### DIFF
--- a/qiskit/primitives/backend_estimator_v2.py
+++ b/qiskit/primitives/backend_estimator_v2.py
@@ -328,7 +328,7 @@ class BackendEstimatorV2(BaseEstimatorV2):
         Returns:
             The map of expectation values takes a pair of an index of the bindings array and
             a pauli string as a key and returns the expectation value of the pauli string
-            with the the pub's circuit bound against the parameter value set in the index of
+            with the circuit bound against the parameter value set in the index of
             the bindings array.
         """
         expval_map: dict[tuple[tuple[int, ...], str], tuple[float, float]] = {}


### PR DESCRIPTION
## Summary
- fix a double word in `_calc_expval_map` docstring

## Testing
- `ruff check qiskit/primitives/backend_estimator_v2.py`
- `black --check qiskit/primitives/backend_estimator_v2.py`
- `make test` *(fails: ModuleNotFoundError: No module named 'ddt')*

------
https://chatgpt.com/codex/tasks/task_e_684333feadd4832fa45cb649fda29c06